### PR TITLE
운영 RestDocs 일부 잘못된 문서 경로를 수정한다.

### DIFF
--- a/backend/src/docs/asciidoc/api/v1/comments.adoc
+++ b/backend/src/docs/asciidoc/api/v1/comments.adoc
@@ -374,8 +374,8 @@ include::{snippets}/api/v1/comments/patch/fail-not-mine/response-fields.adoc[]
 
 ==== Response
 
-include::{snippets}/api/v1/comments/patch/fail-guest-password-wrong/http-response.adoc[]
-include::{snippets}/api/v1/comments/patch/fail-guest-password-wrong/response-fields.adoc[]
+include::{snippets}/api/v1/comments/secret-comment/guest-user/get/fail-not-mine/http-response.adoc[]
+include::{snippets}/api/v1/comments/secret-comment/guest-user/get/fail-not-mine/response-fields.adoc[]
 
 === 댓글 삭제 (DELETE /api/v1/comments)
 


### PR DESCRIPTION
## 구현 사항
- 댓글 수정 API 쪽에서 문서 경로를 수정하였다.