### PR TITLE
액세스 토큰과 리프레쉬 토큰을 이용하여 JWT 토큰의 취약점을 보완한다.

### DIFF
--- a/backend/src/docs/asciidoc/api/v1/auth-login.adoc
+++ b/backend/src/docs/asciidoc/api/v1/auth-login.adoc
@@ -25,15 +25,24 @@ include::{snippets}/api/v1/login-refresh/post/success/http-request.adoc[]
 include::{snippets}/api/v1/login-refresh/post/success/http-response.adoc[]
 include::{snippets}/api/v1/login-refresh/post/success/response-fields.adoc[]
 
-//==== Response (실패 - 리프레시 토큰의 인증이 실패하는 경우)
-//
-//include::{snippets}/api/v1/login-refresh/post/fail/http-response.adoc[]
-//include::{snippets}/api/v1/login-refresh/post/fail/response-fields.adoc[]
+==== Response (실패 - 리프레시 토큰이 존재하지 않는 경우)
 
+include::{snippets}/api/v1/login-refresh-not-refresh-token/post/fail/http-response.adoc[]
+include::{snippets}/api/v1/login-refresh-not-refresh-token/post/fail/response-fields.adoc[]
+
+==== Response (실패 - 이미 액세스 토큰이 유효한 경우)
+
+include::{snippets}/api/v1/login-refresh-already-validated-access-token/post/fail/http-response.adoc[]
+include::{snippets}/api/v1/login-refresh-already-validated-access-token/post/fail/response-fields.adoc[]
+
+==== Response (실패 - 리프레시 토큰이 유효하지 않는 경우)
+
+include::{snippets}/api/v1/login-refresh-not-validated-refresh-token/post/fail/http-response.adoc[]
+include::{snippets}/api/v1/login-refresh-not-validated-refresh-token/post/fail/response-fields.adoc[]
 
 === 로그 아웃 (POST /api/v1/log-out)
 
-==== Response (성공 - 리프레시 토큰의 인증이 실패하는 경우)
+==== Response (성공 - 로그 아웃이 성공하는 경우)
 
 include::{snippets}/api/v1/log-out/post/success/http-request.adoc[]
 include::{snippets}/api/v1/log-out/post/success/http-response.adoc[]

--- a/backend/src/docs/asciidoc/api/v1/comments.adoc
+++ b/backend/src/docs/asciidoc/api/v1/comments.adoc
@@ -302,6 +302,7 @@ include::{snippets}/api/v1/comments/stat/get/monthly/success/response-fields.ado
 === 비밀 댓글 조회 (GET /api/v1/comments/{id}/secret-comment)
 
 ==== (성공) 비로그인 유저가 비밀 댓글 조회
+
 ==== Request
 
 include::{snippets}/api/v1/comments/secret-comment/guest-user/get/success/http-request.adoc[]
@@ -311,7 +312,6 @@ include::{snippets}/api/v1/comments/secret-comment/guest-user/get/success/reques
 
 include::{snippets}/api/v1/comments/secret-comment/guest-user/get/success/http-response.adoc[]
 include::{snippets}/api/v1/comments/secret-comment/guest-user/get/success/response-fields.adoc[]
-
 
 ==== (실패) 비로그인 유저가 비밀 댓글 조회
 
@@ -323,7 +323,6 @@ include::{snippets}/api/v1/comments/secret-comment/guest-user/get/fail-not-mine/
 
 include::{snippets}/api/v1/comments/secret-comment/guest-user/get/fail-not-mine/http-response.adoc[]
 include::{snippets}/api/v1/comments/secret-comment/guest-user/get/fail-not-mine/response-fields.adoc[]
-
 
 ==== (실패) 소셜 로그인 유저가 남의 비밀 댓글 조회
 

--- a/backend/src/main/java/com/darass/auth/controller/OAuthController.java
+++ b/backend/src/main/java/com/darass/auth/controller/OAuthController.java
@@ -30,7 +30,7 @@ public class OAuthController {
     }
 
     @PostMapping("/login/refresh")
-    public ResponseEntity<AccessTokenResponse> regenerateAccessToken(@RequestBody(required = false) @Valid RefreshTokenRequest refreshTokenRequest) {
+    public ResponseEntity<AccessTokenResponse> regenerateAccessToken(@RequestBody @Valid RefreshTokenRequest refreshTokenRequest) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(oAuthService.getAccessTokenWithRefreshToken(refreshTokenRequest.getRefreshToken()));
     }

--- a/backend/src/main/java/com/darass/auth/controller/OAuthController.java
+++ b/backend/src/main/java/com/darass/auth/controller/OAuthController.java
@@ -30,7 +30,7 @@ public class OAuthController {
     }
 
     @PostMapping("/login/refresh")
-    public ResponseEntity<AccessTokenResponse> regenerateAccessToken(@RequestBody @Valid RefreshTokenRequest refreshTokenRequest) {
+    public ResponseEntity<AccessTokenResponse> regenerateAccessToken(@RequestBody(required = false) @Valid RefreshTokenRequest refreshTokenRequest) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(oAuthService.getAccessTokenWithRefreshToken(refreshTokenRequest.getRefreshToken()));
     }

--- a/backend/src/main/java/com/darass/auth/dto/RefreshTokenRequest.java
+++ b/backend/src/main/java/com/darass/auth/dto/RefreshTokenRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RefreshTokenRequest {
 
-    @NotNull
+    @NotNull(message = "refreshToken은 비어 있으면 안 됩니다.")
     private String refreshToken;
 
 }

--- a/backend/src/main/java/com/darass/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/darass/auth/infrastructure/JwtTokenProvider.java
@@ -54,6 +54,10 @@ public class JwtTokenProvider {
         return refreshToken;
     }
 
+    public boolean isValidatedAccessToken(String accessToken) {
+        return isValidateToken(accessToken, secretKeyOfAccessToken);
+    }
+
     public void validateAccessToken(String accessToken) {
         if (!isValidateToken(accessToken, secretKeyOfAccessToken)) {
             throw ExceptionWithMessageAndCode.INVALID_JWT_TOKEN.getException();

--- a/backend/src/main/java/com/darass/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/darass/auth/infrastructure/JwtTokenProvider.java
@@ -27,11 +27,17 @@ public class JwtTokenProvider {
     private long validityInMillisecondsOfRefreshToken;
 
     public String createAccessToken(SocialLoginUser socialLoginUser) {
+        if (isValidateToken(socialLoginUser.getAccessToken(), secretKeyOfAccessToken)) {
+            return socialLoginUser.getAccessToken();
+        }
+
         Claims claims = Jwts.claims().setSubject(socialLoginUser.getId().toString());
         Date now = new Date();
         Date validity = new Date(now.getTime() + validityInMillisecondsOfAccessToken);
 
-        return createJwtToken(claims, now, validity, secretKeyOfAccessToken);
+        String accessToken = createJwtToken(claims, now, validity, secretKeyOfAccessToken);
+        socialLoginUser.updateAccessToken(accessToken);
+        return accessToken;
     }
 
     public String createRefreshToken(SocialLoginUser socialLoginUser) {

--- a/backend/src/main/java/com/darass/auth/service/OAuthService.java
+++ b/backend/src/main/java/com/darass/auth/service/OAuthService.java
@@ -56,7 +56,13 @@ public class OAuthService {
                 throw ExceptionWithMessageAndCode.NOT_EXISTS_REFRESH_TOKEN.getException();
             });
 
-        return new AccessTokenResponse(jwtTokenProvider.createAccessToken(socialLoginUser));
+        if (jwtTokenProvider.isValidatedAccessToken(socialLoginUser.getAccessToken())) {
+            throw ExceptionWithMessageAndCode.ALREADY_VALIDATED_ACCESS_TOKEN.getException();
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(socialLoginUser);
+        socialLoginUser.updateAccessToken(accessToken);
+        return new AccessTokenResponse(accessToken);
     }
 
     public void logOut(SocialLoginUser socialLoginUser) {

--- a/backend/src/main/java/com/darass/auth/service/OAuthService.java
+++ b/backend/src/main/java/com/darass/auth/service/OAuthService.java
@@ -60,6 +60,7 @@ public class OAuthService {
     }
 
     public void logOut(SocialLoginUser socialLoginUser) {
+        socialLoginUser.deleteAccessToken();
         socialLoginUser.deleteRefreshToken();
     }
 }

--- a/backend/src/main/java/com/darass/exception/ExceptionWithMessageAndCode.java
+++ b/backend/src/main/java/com/darass/exception/ExceptionWithMessageAndCode.java
@@ -32,6 +32,7 @@ public enum ExceptionWithMessageAndCode {
     NOT_EXISTS_ACCESS_TOKEN(new UnauthorizedException("엑세스 토큰이 존재하지 않습니다.", 806)),
     NOT_EXISTS_REFRESH_TOKEN(new UnauthorizedException("리프레쉬 토큰이 존재하지 않습니다.", 807)),
     INVALID_REFRESH_TOKEN(new UnauthorizedException("리프레쉬 토큰이 유효하지 않습니다.", 808)),
+    ALREADY_VALIDATED_ACCESS_TOKEN(new UnauthorizedException("이미 유효한 액세스 토큰을 갱신할 수 없습니다", 809)),
 
     // 댓글 관련 : 9xx
     NOT_FOUND_COMMENT(new NotFoundException("해당하는 댓글이 없습니다.", 900)),

--- a/backend/src/main/java/com/darass/exception/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/darass/exception/controller/ControllerAdvice.java
@@ -8,7 +8,6 @@ import com.darass.exception.httpbasicexception.UnauthorizedException;
 import com.darass.slack.SlackMessageSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;

--- a/backend/src/main/java/com/darass/exception/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/darass/exception/controller/ControllerAdvice.java
@@ -6,25 +6,36 @@ import com.darass.exception.httpbasicexception.ConflictException;
 import com.darass.exception.httpbasicexception.NotFoundException;
 import com.darass.exception.httpbasicexception.UnauthorizedException;
 import com.darass.slack.SlackMessageSender;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@RequiredArgsConstructor
 @Slf4j
 @RestControllerAdvice
 public class ControllerAdvice {
 
-    @Autowired
-    private SlackMessageSender slackMessageSender;
+    private final SlackMessageSender slackMessageSender;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        return new ExceptionResponse(e.getMessage(), HttpStatus.BAD_REQUEST.value());
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder builder = new StringBuilder();
+        String message = "%s 입력된 값: [%s]";
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            builder.append(String.format(message, fieldError.getDefaultMessage(), fieldError.getRejectedValue()));
+        }
+
+        return new ExceptionResponse(builder.toString(), HttpStatus.BAD_REQUEST.value());
     }
 
     @ExceptionHandler(BadRequestException.class)

--- a/backend/src/main/java/com/darass/healthcheck/controller/HealthCheckController.java
+++ b/backend/src/main/java/com/darass/healthcheck/controller/HealthCheckController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthCheckController {
+
     @GetMapping("/health")
     public ResponseEntity<Void> healthCheck() {
         return ResponseEntity.status(HttpStatus.OK).body(null);

--- a/backend/src/main/java/com/darass/slack/SlackMessageSender.java
+++ b/backend/src/main/java/com/darass/slack/SlackMessageSender.java
@@ -1,7 +1,6 @@
 package com.darass.slack;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;

--- a/backend/src/main/java/com/darass/slack/SlackRequestDto.java
+++ b/backend/src/main/java/com/darass/slack/SlackRequestDto.java
@@ -1,6 +1,7 @@
 package com.darass.slack;
 
 public class SlackRequestDto {
+
     private String text;
 
     public SlackRequestDto(String text) {

--- a/backend/src/main/java/com/darass/user/domain/SocialLoginUser.java
+++ b/backend/src/main/java/com/darass/user/domain/SocialLoginUser.java
@@ -22,14 +22,17 @@ public class SocialLoginUser extends User {
 
     private String refreshToken;
 
+    private String accessToken;
+
     @Builder
     public SocialLoginUser(Long id, String nickName, String profileImageUrl, String userType, String oauthId,
-        String oauthProvider, String email, String refreshToken) {
+        String oauthProvider, String email, String refreshToken, String accessToken) {
         super(id, nickName, profileImageUrl, userType);
         this.oauthId = oauthId;
         this.oauthProvider = oauthProvider;
         this.email = email;
         this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
     }
 
     @Override
@@ -58,6 +61,10 @@ public class SocialLoginUser extends User {
             String imageUrl = s3Service.upload(profileImageFile);
             changeProfileImageUrl(imageUrl);
         }
+    }
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/backend/src/main/java/com/darass/user/domain/SocialLoginUser.java
+++ b/backend/src/main/java/com/darass/user/domain/SocialLoginUser.java
@@ -71,6 +71,10 @@ public class SocialLoginUser extends User {
         this.refreshToken = refreshToken;
     }
 
+    public void deleteAccessToken() {
+        accessToken = null;
+    }
+
     public void deleteRefreshToken() {
         refreshToken = null;
     }

--- a/backend/src/main/java/com/darass/user/infrastructure/S3Service.java
+++ b/backend/src/main/java/com/darass/user/infrastructure/S3Service.java
@@ -8,7 +8,6 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -27,14 +26,11 @@ public class S3Service {
     private static final String FILE_NAME_FORMAT = "%s-%s-%s";
 
     private static final DateTimeFormatter NOW_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-
+    private final S3Client s3Client;
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
-
     @Value("${name}")
     private String profileName;
-
-    private final S3Client s3Client;
 
     public String upload(MultipartFile multipartFile) {
         File uploadFile = convert(multipartFile);

--- a/backend/src/main/resources/db/migration/V20210809145343__add_sub_comment.sql
+++ b/backend/src/main/resources/db/migration/V20210809145343__add_sub_comment.sql
@@ -1,4 +1,5 @@
-alter table comment add parent_id bigint;
+alter table comment
+    add parent_id bigint;
 
 alter table comment
     add constraint comment_fk_sub_comment

--- a/backend/src/main/resources/db/migration/V20210810143035__add_oauth-provider.sql
+++ b/backend/src/main/resources/db/migration/V20210810143035__add_oauth-provider.sql
@@ -1,1 +1,1 @@
-alter table social_login_user change oauth_provider_type oauth_provider varchar(255);
+alter table social_login_user change oauth_provider_type oauth_provider varchar (255);

--- a/backend/src/main/resources/db/migration/V20210926143035__add_comment_alram.sql
+++ b/backend/src/main/resources/db/migration/V20210926143035__add_comment_alram.sql
@@ -1,11 +1,11 @@
 create table comment_alarm
 (
-    id      bigint not null auto_increment,
+    id                 bigint      not null auto_increment,
     comment_alarm_type varchar(31) not null,
-    created_date  TIMESTAMP,
-    modified_date TIMESTAMP,
-    sender_id       bigint,
-    comment_id    bigint,
+    created_date       TIMESTAMP,
+    modified_date      TIMESTAMP,
+    sender_id          bigint,
+    comment_id         bigint,
     primary key (id)
 );
 

--- a/backend/src/main/resources/db/migration/V20210927143035__add_user_field.sql
+++ b/backend/src/main/resources/db/migration/V20210927143035__add_user_field.sql
@@ -1,1 +1,2 @@
-alter table user add has_recent_alarm BOOLEAN;
+alter table user
+    add has_recent_alarm BOOLEAN;

--- a/backend/src/main/resources/db/migration/V20210928143035__add_receiver.sql
+++ b/backend/src/main/resources/db/migration/V20210928143035__add_receiver.sql
@@ -1,4 +1,5 @@
-alter table comment_alarm add receiver_id bigint;
+alter table comment_alarm
+    add receiver_id bigint;
 
 alter table comment_alarm
     add constraint comment_alarm_fk_receiver

--- a/backend/src/main/resources/db/migration/V20211009120406__add_secret_field.sql
+++ b/backend/src/main/resources/db/migration/V20211009120406__add_secret_field.sql
@@ -1,1 +1,2 @@
-alter table comment add secret BOOLEAN;
+alter table comment
+    add secret BOOLEAN;

--- a/backend/src/main/resources/db/migration/V20220206113312__add_social_login_user_access_token_field.sql
+++ b/backend/src/main/resources/db/migration/V20220206113312__add_social_login_user_access_token_field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE social_login_user
+    ADD COLUMN `access_token` VARCHAR(255) NULL;

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,8 +1,5 @@
 <configuration>
 
-  <springProperty scope="context" name="LOGBACK_HOST" source="logback.destination.host"/>
-  <springProperty scope="context" name="LOGBACK_PORT" source="logback.destination.port"/>
-
   <springProfile name="!prod">
     <appender class="ch.qos.logback.core.ConsoleAppender" name="STDOUT">
       <encoder>
@@ -16,7 +13,6 @@
       <appender-ref ref="STDOUT"/>
     </root>
   </springProfile>
-
   <springProfile name="prod">
     <appender class="ch.qos.logback.core.ConsoleAppender" name="STDOUT">
       <encoder>
@@ -78,4 +74,8 @@
       <appender-ref ref="stash"/>
     </root>
   </springProfile>
+
+  <springProperty name="LOGBACK_PORT" scope="context" source="logback.destination.port"/>
+
+  <springProperty name="LOGBACK_HOST" scope="context" source="logback.destination.host"/>
 </configuration>

--- a/backend/src/test/java/com/darass/auth/api/domain/OAuthProviderFactoryTest.java
+++ b/backend/src/test/java/com/darass/auth/api/domain/OAuthProviderFactoryTest.java
@@ -3,11 +3,11 @@ package com.darass.auth.api.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.darass.SpringContainerTest;
 import com.darass.auth.domain.GithubOAuthProvider;
 import com.darass.auth.domain.KaKaoOAuthProvider;
 import com.darass.auth.domain.NaverOAuthProvider;
 import com.darass.auth.domain.OAuthProviderFactory;
-import com.darass.SpringContainerTest;
 import com.darass.exception.ExceptionWithMessageAndCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/darass/auth/oauth/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/darass/auth/oauth/acceptance/AuthAcceptanceTest.java
@@ -199,27 +199,27 @@ class AuthAcceptanceTest extends MockSpringContainerTest {
     private void 리프레시_토큰_요청_객체가_존재_하지않아_엑세스_토큰_재발급_실패됨(ResultActions tokenRefreshResultActions)
         throws Exception {
         tokenRefreshResultActions.andExpect(status().is5xxServerError());
-
-        토큰_인증_로그인_실패_rest_doc_작성(tokenRefreshResultActions);
     }
 
     private void 리프레시_토큰이_존재_하지않아_엑세스_토큰_재발급_실패됨(ResultActions tokenRefreshResultActions)
         throws Exception {
         tokenRefreshResultActions.andExpect(status().isBadRequest());
+
+        존재하지_않는_리프레시_토큰으로_인해_액세스_토큰_재발급_실패_rest_doc_작성(tokenRefreshResultActions);
     }
 
     private void 이미_유효한_액세스_토큰으로_인해_액세스_토큰_재발급_실패됨(ResultActions tokenRefreshResultActions)
         throws Exception {
         tokenRefreshResultActions.andExpect(status().is4xxClientError());
 
-        토큰_인증_로그인_실패_rest_doc_작성(tokenRefreshResultActions);
+        이미_유효한_엑세스_토큰으로_인해_액세스_토큰_재발급_실패_rest_doc_작성(tokenRefreshResultActions);
     }
 
     private void 유효하지_않은_리프레쉬_토큰으로_인해_엑세스_토큰_재발급_실패됨(ResultActions tokenRefreshResultActions)
         throws Exception {
         tokenRefreshResultActions.andExpect(status().is4xxClientError());
 
-        토큰_인증_로그인_실패_rest_doc_작성(tokenRefreshResultActions);
+        유효하지_않은_리프레시_토큰으로_인해_액세스_토큰_재발급_실패_rest_doc_작성(tokenRefreshResultActions);
     }
 
     private ResultActions 토큰_리프레시_요청(RefreshTokenRequest refreshTokenRequest) throws Exception {
@@ -307,6 +307,36 @@ class AuthAcceptanceTest extends MockSpringContainerTest {
     private void 토큰_인증_로그인_실패_rest_doc_작성(ResultActions resultActions) throws Exception {
         resultActions.andDo(
             document("api/v1/auth-login/post/fail",
+                responseFields(
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("에러 코드")
+                ))
+        );
+    }
+
+    private void 존재하지_않는_리프레시_토큰으로_인해_액세스_토큰_재발급_실패_rest_doc_작성(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+            document("api/v1/login-refresh-not-refresh-token/post/fail",
+                responseFields(
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("에러 코드")
+                ))
+        );
+    }
+
+    private void 이미_유효한_엑세스_토큰으로_인해_액세스_토큰_재발급_실패_rest_doc_작성(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+            document("api/v1/login-refresh-already-validated-access-token/post/fail",
+                responseFields(
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("에러 코드")
+                ))
+        );
+    }
+
+    private void 유효하지_않은_리프레시_토큰으로_인해_액세스_토큰_재발급_실패_rest_doc_작성(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+            document("api/v1/login-refresh-not-validated-refresh-token/post/fail",
                 responseFields(
                     fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("에러 코드")

--- a/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
+++ b/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
@@ -132,4 +132,15 @@ class OAuthServiceTest extends MockSpringContainerTest {
             .isInstanceOf(ExceptionWithMessageAndCode.SHOULD_LOGIN.getException().getClass());
     }
 
+    @DisplayName("로그아웃을 하면 액세스 토큰과 리프레시 토큰이 null이 된다.")
+    @Test
+    void log_out() {
+        TokenRequest tokenRequest = new TokenRequest(KaKaoOAuthProvider.NAME, AUTHORIZATION_CODE);
+        oAuthService.oauthLogin(tokenRequest);
+
+        oAuthService.logOut(socialLoginUser);
+        assertThat(socialLoginUser.getAccessToken()).isNull();
+        assertThat(socialLoginUser.getRefreshToken()).isNull();
+    }
+
 }

--- a/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
+++ b/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
@@ -83,6 +83,7 @@ class OAuthServiceTest extends MockSpringContainerTest {
         assertThat(possibleSocialLoginUser.isPresent()).isTrue();
 
         SocialLoginUser socialLoginUser = possibleSocialLoginUser.get();
+        assertThat(socialLoginUser.getAccessToken()).isEqualTo(tokenResponse.getAccessToken());
         assertThat(socialLoginUser.getRefreshToken()).isEqualTo(tokenResponse.getRefreshToken());
     }
 

--- a/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
+++ b/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
@@ -14,10 +14,13 @@ import com.darass.auth.infrastructure.JwtTokenProvider;
 import com.darass.exception.ExceptionWithMessageAndCode;
 import com.darass.user.domain.SocialLoginUser;
 import java.util.Optional;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("OAuthService 클래스")
 class OAuthServiceTest extends MockSpringContainerTest {
@@ -29,6 +32,9 @@ class OAuthServiceTest extends MockSpringContainerTest {
 
     @Autowired
     private OAuthService oAuthService;
+
+    @Autowired
+    private EntityManager entityManager;
 
     private SocialLoginUser socialLoginUser;
 
@@ -105,12 +111,15 @@ class OAuthServiceTest extends MockSpringContainerTest {
         assertThat(result.getEmail()).isEqualTo(socialLoginUser.getEmail());
     }
 
-    @DisplayName("유효한 refreshToken이 주어지면, accessToken을 발급해준다.")
+    @DisplayName("유효한 refreshToken이 주어지고, DB의 accessToken이 유효하지 않다면 accessToken을 발급해준다.")
+    @Transactional
     @Test
     void getAccessTokenWithRefreshToken() throws InterruptedException {
         //given
         TokenRequest tokenRequest = new TokenRequest(KaKaoOAuthProvider.NAME, AUTHORIZATION_CODE);
         TokenResponse tokenResponse = oAuthService.oauthLogin(tokenRequest);
+        socialLoginUser.updateAccessToken(null);
+        entityManager.flush();
 
         Thread.sleep(1000);
 
@@ -119,6 +128,18 @@ class OAuthServiceTest extends MockSpringContainerTest {
 
         //then
         assertThat(tokenResponse.getAccessToken()).isNotEqualTo(accessTokenResponse.getAccessToken());
+    }
+
+    @DisplayName("유효한 refreshToken이 주어지고, DB의 accessToken이 유효하다면 예외를 던진다.")
+    @Test
+    void getAccessTokenWithRefreshToken_alreay_validated_access_token() throws InterruptedException {
+        TokenRequest tokenRequest = new TokenRequest(KaKaoOAuthProvider.NAME, AUTHORIZATION_CODE);
+        TokenResponse tokenResponse = oAuthService.oauthLogin(tokenRequest);
+
+        Thread.sleep(1000);
+
+        assertThatThrownBy(() -> oAuthService.getAccessTokenWithRefreshToken(tokenResponse.getRefreshToken()))
+        .isInstanceOf(ExceptionWithMessageAndCode.ALREADY_VALIDATED_ACCESS_TOKEN.getException().getClass());
     }
 
     @DisplayName("refreshAccessTokenWithRefreshToken 메서드는 refreshToken이 db에 존재하지 않는다면, 예외를 던진다.")

--- a/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
+++ b/backend/src/test/java/com/darass/auth/service/OAuthServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("OAuthService 클래스")
@@ -139,7 +138,7 @@ class OAuthServiceTest extends MockSpringContainerTest {
         Thread.sleep(1000);
 
         assertThatThrownBy(() -> oAuthService.getAccessTokenWithRefreshToken(tokenResponse.getRefreshToken()))
-        .isInstanceOf(ExceptionWithMessageAndCode.ALREADY_VALIDATED_ACCESS_TOKEN.getException().getClass());
+            .isInstanceOf(ExceptionWithMessageAndCode.ALREADY_VALIDATED_ACCESS_TOKEN.getException().getClass());
     }
 
     @DisplayName("refreshAccessTokenWithRefreshToken 메서드는 refreshToken이 db에 존재하지 않는다면, 예외를 던진다.")

--- a/backend/src/test/java/com/darass/comment/acceptance/CommentAcceptanceTest.java
+++ b/backend/src/test/java/com/darass/comment/acceptance/CommentAcceptanceTest.java
@@ -22,14 +22,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.darass.MockSpringContainerTest;
-import com.darass.SpringContainerTest;
 import com.darass.auth.infrastructure.JwtTokenProvider;
 import com.darass.comment.dto.CommentCreateRequest;
 import com.darass.comment.dto.CommentReadSecretCommentRequest;
 import com.darass.comment.dto.CommentResponse;
 import com.darass.comment.dto.CommentResponses;
 import com.darass.comment.dto.CommentUpdateRequest;
-import com.darass.commentalarm.domain.CommentAlarmMachine;
 import com.darass.exception.ExceptionWithMessageAndCode;
 import com.darass.project.domain.Project;
 import com.darass.project.repository.ProjectRepository;
@@ -43,7 +41,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -1485,7 +1482,7 @@ class CommentAcceptanceTest extends MockSpringContainerTest {
 
     @DisplayName("비로그인 유저가 비밀 댓글을 조회한다.")
     @Test
-    void readSecretComment_guest_user() throws Exception{
+    void readSecretComment_guest_user() throws Exception {
         CommentResponse commentResponse = 비로그인_댓글_등록됨_Response_반환("content1", "url", true);
         소셜_로그인_대댓글_등록됨("content2", "url", commentResponse.getId(), true);
         소셜_로그인_대댓글_등록됨("content3", "url", commentResponse.getId(), true);
@@ -1542,7 +1539,7 @@ class CommentAcceptanceTest extends MockSpringContainerTest {
 
     @DisplayName("소셜 로그인 유저는 남의 비밀 댓글을 조회할 수 없다.")
     @Test
-    void readSecretComment_login_user() throws Exception{
+    void readSecretComment_login_user() throws Exception {
         CommentResponse commentResponse1 = 소셜_로그인_댓글_등록됨_Response_반환("content1", "url");
         CommentResponse commentResponse2 = 비로그인_댓글_등록됨_Response_반환("content2", "url", true);
         Long commentId2 = commentResponse2.getId();
@@ -1602,7 +1599,7 @@ class CommentAcceptanceTest extends MockSpringContainerTest {
 
     @DisplayName("비로그인 유저가 비밀번호를 틀리면 비밀 댓글을 조회할 수 없다.")
     @Test
-    void readSecretComment_guest_user_exception() throws Exception{
+    void readSecretComment_guest_user_exception() throws Exception {
         CommentResponse commentResponse = 비로그인_댓글_등록됨_Response_반환("content2", "url");
         Long commentId = commentResponse.getId();
         UserResponse user = commentResponse.getUser();

--- a/backend/src/test/java/com/darass/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/darass/comment/controller/CommentControllerTest.java
@@ -33,27 +33,26 @@ public class CommentControllerTest {
     private static GuestUser guestUser;
     private static SocialLoginUser socialLoginUser;
 
-    @Autowired
-    private MockMvc mockMvc;
-
     static {
         guestUser = GuestUser.builder()
-                .id(1L)
-                .nickName("user")
-                .password("password")
-                .build();
+            .id(1L)
+            .nickName("user")
+            .password("password")
+            .build();
 
         socialLoginUser = SocialLoginUser.builder()
-                .id(1L)
-                .nickName("우기")
-                .profileImageUrl("http://프로필이미지-url")
-                .userType("socialLoginUser")
-                .email("bbwwpark@naver.com")
-                .oauthProvider("kakao")
-                .oauthId("1234")
-                .build();
+            .id(1L)
+            .nickName("우기")
+            .profileImageUrl("http://프로필이미지-url")
+            .userType("socialLoginUser")
+            .email("bbwwpark@naver.com")
+            .oauthProvider("kakao")
+            .oauthId("1234")
+            .build();
     }
 
+    @Autowired
+    private MockMvc mockMvc;
     @MockBean
     private CommentService commentService;
 
@@ -69,16 +68,16 @@ public class CommentControllerTest {
         Long commentId = 1L;
         GuestUser user = new GuestUser();
         given(commentService.readSecretComment(eq(commentId), eq(user), any()))
-                .willReturn(new CommentResponse(1L, "content", "url", true, true, LocalDateTime.now(), LocalDateTime.now(),
-                        null, UserResponse.of(socialLoginUser), null));
+            .willReturn(new CommentResponse(1L, "content", "url", true, true, LocalDateTime.now(), LocalDateTime.now(),
+                null, UserResponse.of(socialLoginUser), null));
 
         mockMvc.perform(get("/api/v1/comments/" + commentId + "/secret-comment")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("guestUserId", String.valueOf(guestUser.getId()))
-                        .param("guestUserPassword", guestUser.getPassword()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").value("content"))
-                .andExpect(jsonPath("$.secret").value(true));
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("guestUserId", String.valueOf(guestUser.getId()))
+            .param("guestUserPassword", guestUser.getPassword()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").value("content"))
+            .andExpect(jsonPath("$.secret").value(true));
     }
 
     @DisplayName("비로그인 유저가 비밀번호를 틀리면 비밀 댓글을 조회할 수 없다.")
@@ -88,13 +87,13 @@ public class CommentControllerTest {
         GuestUser user = new GuestUser();
 
         given(commentService.readSecretComment(eq(commentId), eq(user), any()))
-                .willThrow(UnauthorizedException.class);
+            .willThrow(UnauthorizedException.class);
 
         mockMvc.perform(get("/api/v1/comments/" + commentId + "/secret-comment")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("guestUserId", String.valueOf(guestUser.getId()))
-                        .param("guestUserPassword", "Invalid"))
-                .andExpect(status().isUnauthorized());
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("guestUserId", String.valueOf(guestUser.getId()))
+            .param("guestUserPassword", "Invalid"))
+            .andExpect(status().isUnauthorized());
     }
 
     @DisplayName("소셜로그인 유저는 남의 비밀 댓글을 조회할 수 없다.")
@@ -103,14 +102,14 @@ public class CommentControllerTest {
         Long commentId = 1L;
 
         given(oAuthService.findSocialLoginUserByAccessToken(ACCESS_TOKEN))
-                .willReturn(socialLoginUser);
+            .willReturn(socialLoginUser);
 
         given(commentService.readSecretComment(eq(commentId), eq(socialLoginUser), any()))
-                .willThrow(UnauthorizedException.class);
+            .willThrow(UnauthorizedException.class);
 
         mockMvc.perform(get("/api/v1/comments/" + commentId + "/secret-comment")
-                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized());
+            .header("Authorization", "Bearer " + ACCESS_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
     }
 }

--- a/backend/src/test/java/com/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/comment/service/CommentServiceTest.java
@@ -392,7 +392,7 @@ class CommentServiceTest extends SpringContainerTest {
     @Test
     void stat_monthly() {
         LocalDate endDate = LocalDate.now();
-        LocalDate startDate = endDate.minusMonths(4L).minusDays(1L);
+        LocalDate startDate = endDate.minusMonths(4L);
         CommentStatRequest request = new CommentStatRequest("MONTHLY", project.getSecretKey(),
             startDate, endDate);
         CommentStatResponse commentStatResponse = commentService.giveStat(request);

--- a/backend/src/test/java/com/darass/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/darass/comment/service/CommentServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
+import com.darass.SpringContainerTest;
 import com.darass.auth.domain.KaKaoOAuthProvider;
 import com.darass.comment.domain.Comment;
 import com.darass.comment.domain.CommentLike;
@@ -27,7 +28,6 @@ import com.darass.commentalarm.domain.CommentAlarm;
 import com.darass.commentalarm.domain.CommentAlarmMachine;
 import com.darass.commentalarm.domain.CommentAlarmType;
 import com.darass.commentalarm.repository.CommentAlarmRepository;
-import com.darass.SpringContainerTest;
 import com.darass.exception.httpbasicexception.BadRequestException;
 import com.darass.exception.httpbasicexception.NotFoundException;
 import com.darass.exception.httpbasicexception.UnauthorizedException;

--- a/backend/src/test/java/com/darass/commentalarm/controller/CommentAlarmControllerTest.java
+++ b/backend/src/test/java/com/darass/commentalarm/controller/CommentAlarmControllerTest.java
@@ -40,12 +40,6 @@ class CommentAlarmControllerTest extends MockSpringContainerTest {
     private static final SocialLoginUser SENDER;
     private static final SocialLoginUser RECEIVER;
 
-    @MockBean
-    CommentAlarmService mockCommentAlarmService;
-
-    @MockBean
-    OAuthService mockOAuthService;
-
     static {
         SENDER = SocialLoginUser
             .builder()
@@ -71,6 +65,11 @@ class CommentAlarmControllerTest extends MockSpringContainerTest {
             .userType("SocialLoginUser")
             .build();
     }
+
+    @MockBean
+    CommentAlarmService mockCommentAlarmService;
+    @MockBean
+    OAuthService mockOAuthService;
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/com/darass/commentalarm/repository/CommentAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/darass/commentalarm/repository/CommentAlarmRepositoryTest.java
@@ -2,11 +2,11 @@ package com.darass.commentalarm.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.darass.SpringContainerTest;
 import com.darass.comment.domain.Comment;
 import com.darass.comment.repository.CommentRepository;
 import com.darass.commentalarm.domain.CommentAlarm;
 import com.darass.commentalarm.domain.CommentAlarmType;
-import com.darass.SpringContainerTest;
 import com.darass.user.domain.SocialLoginUser;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/src/test/java/com/darass/commentalarm/service/CommentAlarmServiceTest.java
+++ b/backend/src/test/java/com/darass/commentalarm/service/CommentAlarmServiceTest.java
@@ -2,12 +2,12 @@ package com.darass.commentalarm.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.darass.SpringContainerTest;
 import com.darass.comment.domain.Comment;
 import com.darass.commentalarm.domain.CommentAlarm;
 import com.darass.commentalarm.domain.CommentAlarmType;
 import com.darass.commentalarm.dto.CommentAlarmResponse;
 import com.darass.commentalarm.repository.CommentAlarmRepository;
-import com.darass.SpringContainerTest;
 import com.darass.user.domain.SocialLoginUser;
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/backend/src/test/java/com/darass/exception/controller/ControllerAdviceTest.java
+++ b/backend/src/test/java/com/darass/exception/controller/ControllerAdviceTest.java
@@ -15,6 +15,7 @@ import com.darass.comment.controller.CommentController;
 import com.darass.comment.dto.CommentCreateRequest;
 import com.darass.SpringContainerTest;
 import com.darass.exception.ExceptionWithMessageAndCode;
+import com.darass.slack.SlackMessageSender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,12 +41,15 @@ class ControllerAdviceTest extends SpringContainerTest {
     @Autowired
     private OAuthService oAuthService;
 
+    @Autowired
+    private SlackMessageSender slackMessageSender;
+
     @DisplayName("handleMethodArgumentNotValidException 메서드는 MethodArgumentNotValidException 예외가 발생하면 http 응답코드 400을 반환한다.")
     @Test
     void handleMethodArgumentNotValidException() throws Exception {
         mockMvc = MockMvcBuilders
             .standaloneSetup(commentController)
-            .setControllerAdvice(new ControllerAdvice())
+            .setControllerAdvice(new ControllerAdvice(slackMessageSender))
             .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver(oAuthService))
             .build();
 
@@ -64,7 +68,7 @@ class ControllerAdviceTest extends SpringContainerTest {
 
         mockMvc = MockMvcBuilders
             .standaloneSetup(oAuthController)
-            .setControllerAdvice(new ControllerAdvice())
+            .setControllerAdvice(new ControllerAdvice(slackMessageSender))
             .build();
 
         mockMvc.perform(post("/api/v1/login/oauth")
@@ -78,7 +82,7 @@ class ControllerAdviceTest extends SpringContainerTest {
     void handleUnauthorizedException() throws Exception {
         mockMvc = MockMvcBuilders
             .standaloneSetup(oAuthController)
-            .setControllerAdvice(new ControllerAdvice())
+            .setControllerAdvice(new ControllerAdvice(slackMessageSender))
             .build();
 
         mockMvc.perform(post("/api/v1/login/oauth")
@@ -92,7 +96,7 @@ class ControllerAdviceTest extends SpringContainerTest {
     void handleNotFoundException() throws Exception {
         mockMvc = MockMvcBuilders
             .standaloneSetup(commentController)
-            .setControllerAdvice(new ControllerAdvice())
+            .setControllerAdvice(new ControllerAdvice(slackMessageSender))
             .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver(oAuthService))
             .build();
 

--- a/backend/src/test/java/com/darass/exception/controller/ControllerAdviceTest.java
+++ b/backend/src/test/java/com/darass/exception/controller/ControllerAdviceTest.java
@@ -7,13 +7,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.darass.SpringContainerTest;
 import com.darass.auth.controller.OAuthController;
 import com.darass.auth.controller.argumentresolver.AuthenticationPrincipalArgumentResolver;
 import com.darass.auth.dto.TokenRequest;
 import com.darass.auth.service.OAuthService;
 import com.darass.comment.controller.CommentController;
 import com.darass.comment.dto.CommentCreateRequest;
-import com.darass.SpringContainerTest;
 import com.darass.exception.ExceptionWithMessageAndCode;
 import com.darass.slack.SlackMessageSender;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/backend/src/test/java/com/darass/slack/SlackMessageSenderTest.java
+++ b/backend/src/test/java/com/darass/slack/SlackMessageSenderTest.java
@@ -3,15 +3,12 @@ package com.darass.slack;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-import org.junit.Ignore;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @SpringBootTest(classes = {
     SlackMessageSender.class

--- a/backend/src/test/java/com/darass/user/infrastructure/S3ServiceTest.java
+++ b/backend/src/test/java/com/darass/user/infrastructure/S3ServiceTest.java
@@ -4,12 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMapOf;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -17,7 +12,6 @@ import com.darass.SpringContainerTest;
 import com.darass.exception.httpbasicexception.BadRequestException;
 import java.io.IOException;
 import java.net.URL;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -28,7 +22,6 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 

--- a/backend/src/test/java/com/darass/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/darass/user/service/UserServiceTest.java
@@ -2,11 +2,11 @@ package com.darass.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.darass.SpringContainerTest;
 import com.darass.comment.domain.Comment;
 import com.darass.comment.domain.CommentLike;
 import com.darass.comment.repository.CommentLikeRepository;
 import com.darass.comment.repository.CommentRepository;
-import com.darass.SpringContainerTest;
 import com.darass.exception.ExceptionWithMessageAndCode;
 import com.darass.project.domain.Project;
 import com.darass.project.repository.ProjectRepository;
@@ -15,7 +15,6 @@ import com.darass.user.domain.SocialLoginUser;
 import com.darass.user.domain.User;
 import com.darass.user.dto.UserResponse;
 import com.darass.user.dto.UserUpdateRequest;
-import com.darass.user.infrastructure.S3Service;
 import com.darass.user.repository.UserRepository;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.Assertions;
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @DisplayName("UserService 클래스")
 class UserServiceTest extends SpringContainerTest {

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -2,15 +2,13 @@ spring.jpa.hibernate.ddl-auto=create
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=20210802223415
 spring.flyway.locations=filesystem:src/test/resources/testdb/migration
-
 spring.main.banner-mode=off
 spring.jpa.show-sql=false
 spring.jpa.generate-ddl=false
-
 logging.level.com.zaxxer.hikari.pool.HikariPool=ERROR
-logging.level.com.zaxxer.hikari.HikariConfig= ERROR
-logging.level.com.zaxxer.hikari.pool.PoolBase= ERROR
-logging.level.com.zaxxer.hikari.HikariDataSource= ERROR
-logging.level.org.hibernate.SQL= ERROR
-logging.level.root= ERROR
-logging.level.org.springframework= ERROR
+logging.level.com.zaxxer.hikari.HikariConfig=ERROR
+logging.level.com.zaxxer.hikari.pool.PoolBase=ERROR
+logging.level.com.zaxxer.hikari.HikariDataSource=ERROR
+logging.level.org.hibernate.SQL=ERROR
+logging.level.root=ERROR
+logging.level.org.springframework=ERROR

--- a/backend/src/test/resources/testdb/migration/V20210809145343__add_sub_comment.sql
+++ b/backend/src/test/resources/testdb/migration/V20210809145343__add_sub_comment.sql
@@ -1,4 +1,5 @@
-alter table comment add parent_id bigint;
+alter table comment
+    add parent_id bigint;
 
 alter table comment
     add constraint comment_fk_sub_comment

--- a/backend/src/test/resources/testdb/migration/V20210810143034__enlarge_comment_size.sql
+++ b/backend/src/test/resources/testdb/migration/V20210810143034__enlarge_comment_size.sql
@@ -1,1 +1,2 @@
-alter table comment alter column content longtext;
+alter table comment
+    alter column content longtext;

--- a/backend/src/test/resources/testdb/migration/V20210810143035__add_oauth-provider.sql
+++ b/backend/src/test/resources/testdb/migration/V20210810143035__add_oauth-provider.sql
@@ -1,1 +1,2 @@
-ALTER TABLE  social_login_user ALTER COLUMN oauth_provider_type RENAME TO oauth_provider;
+ALTER TABLE social_login_user
+    ALTER COLUMN oauth_provider_type RENAME TO oauth_provider;

--- a/backend/src/test/resources/testdb/migration/V20210926143035__add_comment_alram.sql
+++ b/backend/src/test/resources/testdb/migration/V20210926143035__add_comment_alram.sql
@@ -1,11 +1,11 @@
 create table comment_alarm
 (
-    id      bigint not null auto_increment,
+    id                 bigint      not null auto_increment,
     comment_alarm_type varchar(31) not null,
-    created_date  TIMESTAMP,
-    modified_date TIMESTAMP,
-    sender_id       bigint,
-    comment_id    bigint,
+    created_date       TIMESTAMP,
+    modified_date      TIMESTAMP,
+    sender_id          bigint,
+    comment_id         bigint,
     primary key (id)
 );
 

--- a/backend/src/test/resources/testdb/migration/V20210927143035__add_user_field.sql
+++ b/backend/src/test/resources/testdb/migration/V20210927143035__add_user_field.sql
@@ -1,1 +1,2 @@
-alter table user add has_recent_alarm BOOLEAN;
+alter table user
+    add has_recent_alarm BOOLEAN;

--- a/backend/src/test/resources/testdb/migration/V20210928143035__add_receiver.sql
+++ b/backend/src/test/resources/testdb/migration/V20210928143035__add_receiver.sql
@@ -1,4 +1,5 @@
-alter table comment_alarm add receiver_id bigint;
+alter table comment_alarm
+    add receiver_id bigint;
 
 alter table comment_alarm
     add constraint comment_alarm_fk_receiver

--- a/backend/src/test/resources/testdb/migration/V20211009120406__add_secret_field.sql
+++ b/backend/src/test/resources/testdb/migration/V20211009120406__add_secret_field.sql
@@ -1,1 +1,2 @@
-alter table comment add secret BOOLEAN;
+alter table comment
+    add secret BOOLEAN;


### PR DESCRIPTION
close: #37 

## 구현 사항
- 액세스 토큰을 DB 테이블에 추가하고, 그에 따른 로그인 및 로그아웃 로직 구현
- 액세스 토큰 갱신할 때, 액세스 토큰이 유효하지 않은 경우에만 재발급
- 일부 rest-docs 정비